### PR TITLE
add append functionality to db dumping tasks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "consolidation/robo": "~1",
-        "ifsnop/mysqldump-php": "^2.0",
+        "ifsnop/mysqldump-php": "^2.5",
         "php": ">=7.1"
     },
     "require-dev": {

--- a/src/DumpData.php
+++ b/src/DumpData.php
@@ -9,4 +9,15 @@ class DumpData extends Dump
     protected $defaultSettings = [
         'add-drop-table' => true
     ];
+
+    public function append(bool $append = true) : DumpData
+    {
+        if ($append === true) {
+            $this->defaultSettings['add-drop-table'] = false;
+            $this->defaultSettings['no-create-info'] = true;
+            $this->defaultSettings['insert-ignore']  = true;
+        }
+
+        return $this;
+    }
 }

--- a/src/DumpDataPartial.php
+++ b/src/DumpDataPartial.php
@@ -5,7 +5,7 @@ use Robo\Common\BuilderAwareTrait;
 use Robo\Contract\BuilderAwareInterface;
 use Robo\Result;
 
-class DumpDataPartial extends Dump implements BuilderAwareInterface
+class DumpDataPartial extends DumpData implements BuilderAwareInterface
 {
     use BuilderAwareTrait;
 
@@ -38,18 +38,6 @@ class DumpDataPartial extends Dump implements BuilderAwareInterface
         'exclude-tables' => [],
         'where'          => null
     ];
-
-    public function append(bool $append = true) : DumpDataPartial
-    {
-        if ($append === true) {
-            $this->defaultSettings['add-drop-table'] = false;
-            $this->defaultSettings['no-create-info'] = true;
-            // https://github.com/ifsnop/mysqldump-php/pull/130
-            // $this->defaultSettings['insert-ignore'] = false;
-        }
-
-        return $this;
-    }
 
     public function withFilters(array $tableFilters) : DumpDataPartial
     {


### PR DESCRIPTION
This adds an `append()` method to the various DB dumping tasks, which will prevent DROP/CREATE table statements from being issued, and pass the `insert-ignore` option to the mysqldump library, which causes all INSERTS to be written as INSERT IGNORE.